### PR TITLE
Add RPC and action auto generation

### DIFF
--- a/device/molex/x86_64-otn-kvm_x86_64-r0/yang_auto_cli
+++ b/device/molex/x86_64-otn-kvm_x86_64-r0/yang_auto_cli
@@ -1,3 +1,4 @@
 #List yang models, annotation, and optional layout flag for sonic yang generation
 openconfig-optical-attenuator.yang openconfig-optical-attenuator-annot.yang vertical
 openconfig-optical-amplifier.yang openconfig-optical-amplifier-annot.yang vertical
+openconfig-channel-monitor.yang openconfig-channel-monitor-annot.yang

--- a/platform/otn-kvm/sonic-yanggen/sonic_yanggen.py
+++ b/platform/otn-kvm/sonic-yanggen/sonic_yanggen.py
@@ -40,6 +40,8 @@ class Annotation:
         self.info = {}
         self.tables = []
         self.dbs = set()
+        self.rpcs = []
+        self.actions = []
         self.parse()
 
 
@@ -118,6 +120,16 @@ class Annotation:
         self.tables[-1][TB_KEY_IDX] = v
 
 
+    def callback(self, deviation, ext_key, target) -> None:
+        """
+        Parse rpc-callback or action-callback name and append to target list.
+        """
+        if self.leaf_value(deviation, ext_key) is None:
+            return
+
+        xpath = deviation[:deviation.find('{')].strip()[1:-1]
+        target.append(xpath.rsplit('/', 1)[-1].split(':')[-1])
+
     def field_name(self, deviation) -> None:
         """
         Parse field name or field transformer
@@ -169,6 +181,8 @@ class Annotation:
         deviations = content.split(' deviation ')
         for deviation in deviations[1:]:
             deviation = deviation.strip()
+            self.callback(deviation, 'sonic-ext:rpc-callback', self.rpcs)
+            self.callback(deviation, 'sonic-ext:action-callback', self.actions)
             self.table_name(deviation)
             self.key_name(deviation)
             self.field_name(deviation)
@@ -205,11 +219,18 @@ class Generator:
         self.module = self.__load_module()
         self.module_name = self.__name()
         self.field_record = []
+        self._list_action_names = set()
 
 
     def __load_module(self) -> ly.Module:
+        self.imp_modules = []
         for m in self.annot.info['imports']:
-            self.ctx.load_module(m[0])
+            try:
+                self.imp_modules.append(self.ctx.load_module(m[0]))
+            except Exception:
+                # Some imports (e.g. sonic-extensions) may not be present
+                # in the search path; that's fine, just skip them.
+                pass
 
         return self.ctx.load_module(self.annot.info['src_module'][0])
 
@@ -463,6 +484,25 @@ class Generator:
         return text
 
 
+    def _find_actions_in_subtree(self, parent, keep):
+        """
+        Find action schema nodes under parent that match names in keep set.
+        Uses libyang tree traversal via .children() and .nodetype().
+        """
+        found = []
+        try:
+            children = parent.children()
+        except Exception:
+            return found
+        for child in children:
+            nt = child.nodetype()
+            if nt == ly.SNode.ACTION and child.name() in keep:
+                found.append(child)
+            elif nt in (ly.SNode.CONTAINER, ly.SNode.LIST):
+                found.extend(self._find_actions_in_subtree(child, keep))
+        return found
+
+
     def gen_container(self, table) -> str:
         """
         Generate container information for sonic yang
@@ -481,6 +521,14 @@ class Generator:
 
         text += self.gen_list(table)
 
+        # Emit list-level actions that are descendants of this table's schema node
+        if self.annot.actions:
+            keep = set(self.annot.actions) - self._list_action_names
+            if keep:
+                for action_node in self._find_actions_in_subtree(node, keep):
+                    text += self._emit_rpc_or_action(action_node, 'action')
+                    self._list_action_names.add(action_node.name())
+
         text += '}}'
 
         return text
@@ -491,6 +539,8 @@ class Generator:
         Generate header information for sonic yang
         """
         text = 'module ' + self.module_name + ' {'
+        if self.annot.actions:
+            text += 'yang-version "1.1";'
         text += self.namespace()
         text += self.prefix(MODEL_TITLE_DEST)
         text += self.imports()
@@ -513,10 +563,155 @@ class Generator:
             if self.cfg is None or table[TB_DBTYPE_IDX] == self.cfg:
                 text += self.gen_container(table)
 
-        text += '}}'
+        # Actions not already placed in a list go in the outer container
+        text += self.gen_actions()
+
+        text += '}'  # close outer top-level container
 
         return text
-    
+
+    def gen_rpcs(self) -> str:
+        """
+        Generate rpc for sonic yang.
+
+        RPCs may be defined either in the source openconfig module or in
+        an external openconfig module imported by the annotation file
+        (so a single auxiliary module can host RPCs/augments that target
+        multiple upstream models).
+        """
+        if not self.annot.rpcs:
+            return ''
+
+        keep = set(self.annot.rpcs)
+        text = ''
+        for mod in [self.module] + getattr(self, 'imp_modules', []):
+            for rpc in mod.children(types=(ly.SNode.RPC,)):
+                if rpc.name() in keep:
+                    text += self._emit_rpc_or_action(rpc, 'rpc')
+        return text
+
+    def gen_actions(self) -> str:
+        """
+        Generate action statements for sonic yang.
+
+        Only emits actions that were NOT already placed inside a table's
+        list by gen_container (i.e. top-level-container-only actions).
+        """
+        if not self.annot.actions:
+            return ''
+
+        keep = set(self.annot.actions) - self._list_action_names
+        if not keep:
+            return ''
+
+        text = ''
+        for mod in [self.module] + getattr(self, 'imp_modules', []):
+            self._walk_actions(mod, keep, text_parts := [])
+            text += ''.join(text_parts)
+        return text
+
+    def _walk_actions(self, parent, keep, text_parts) -> None:
+        """
+        Recursively walk data tree children to find action nodes.
+        """
+        try:
+            children = parent.children()
+        except Exception:
+            return
+        for child in children:
+            nt = child.nodetype()
+            if nt == ly.SNode.ACTION and child.name() in keep:
+                text_parts.append(self._emit_rpc_or_action(child, 'action'))
+            elif nt in (ly.SNode.CONTAINER, ly.SNode.LIST):
+                self._walk_actions(child, keep, text_parts)
+
+    def _emit_rpc_or_action(self, node, keyword) -> str:
+        """
+        Emit a single rpc or action block as flat YANG text.
+        """
+        text = keyword + ' ' + node.name() + ' {'
+        if node.description():
+            text += 'description "' + node.description() + '";'
+        for io_node, kw in ((node.input(), 'input'), (node.output(), 'output')):
+            if io_node is None:
+                continue
+            text += kw + ' {' + self._emit_inout(io_node) + '}'
+        text += '}'
+        return text
+
+
+    def _emit_inout(self, parent) -> str:
+        """
+        Emit children of an input/output (or container) node
+        """
+        text = ''
+        for child in parent.children():
+            nt = child.nodetype()
+            if nt == ly.SNode.LEAF:
+                text += self._emit_leaf(child, leaf_list=False)
+            elif nt == ly.SNode.LEAFLIST:
+                text += self._emit_leaf(child, leaf_list=True)
+            elif nt == ly.SNode.CONTAINER:
+                text += self._emit_container(child)
+        return text
+
+
+    def _emit_container(self, node) -> str:
+        text = 'container ' + node.name() + ' {'
+        if node.description():
+            text += 'description "' + node.description() + '";'
+        text += self._emit_inout(node)
+        text += '}'
+        return text
+
+
+    def _emit_leaf(self, leaf, leaf_list: bool) -> str:
+        kw = 'leaf-list' if leaf_list else 'leaf'
+        text = kw + ' ' + leaf.name() + ' {'
+        text += self._emit_type(leaf.type())
+        if leaf.mandatory():
+            text += 'mandatory true;'
+        if not leaf_list and leaf.default() is not None:
+            text += 'default "' + str(leaf.default()) + '";'
+        if leaf.units():
+            text += 'units "' + leaf.units() + '";'
+        if leaf.description():
+            text += 'description "' + leaf.description() + '";'
+        text += '}'
+        return text
+
+
+    def _emit_type(self, t) -> str:
+        """
+        Emit a `type ...;` (or `type ... { ... }`) for a libyang Type.
+        SONiC-specific rewrites:
+          - leafref          -> string  (path target may live in a foreign
+                                         module that sonic-yang can't resolve)
+          - foreign-prefixed -> string  (e.g. oc-yang:date-and-time)
+        Enumerations defined via a typedef get expanded inline so the
+        typedef itself never has to be emitted.
+        """
+        base = t.base()
+        name = t.name() or ''
+
+        if base == ly.Type.LEAFREF:
+            return 'type string;'
+        if ':' in name:
+            return 'type string;'
+
+        if base == ly.Type.ENUM:
+            text = 'type enumeration {'
+            for e in t.enums():
+                ev = e.value()
+                if ev is None:
+                    text += 'enum "' + e.name() + '";'
+                else:
+                    text += 'enum "' + e.name() + '" {value ' + str(ev) + ';}'
+            text += '}'
+            return text
+
+        return 'type ' + t.basename() + ';'
+
 
     def gen_yang(self) -> str:
         """
@@ -524,6 +719,8 @@ class Generator:
         """
         text = self.gen_head()
         text += self.gen_tables()
+        text += self.gen_rpcs()
+        text += '}'  # close module
 
         debug_print(text)
         return text

--- a/rules/config
+++ b/rules/config
@@ -217,7 +217,7 @@ ENABLE_AUTO_TECH_SUPPORT = y
 
 # ENABLE_TRANSLIB_WRITE - Enable translib write/config operations via the gNMI interface.
 # Uncomment to enable:
-# ENABLE_TRANSLIB_WRITE = y
+ENABLE_TRANSLIB_WRITE = y
 
 # ENABLE_NATIVE_WRITE - Enable native write/config operations via the gNMI interface.
 ENABLE_NATIVE_WRITE = y


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
In 03/24/2026 SONiC meeting, Alibaba introduces two important requirements:
- sonic-yang units display
- SONiC auto CLI generation tools: RPC support
We have not implemented the whole flow to do the RPC request from north-bound to south-bound, I created **get-ocm-raw** as this PR example.

In 04/01/2026: I found out `action` statement in yang version 1.1 is really suitable for optical industries. (OCM & OTDR) Implement action statement.

#### Basic rules
1. In **Yang version: 1** **augmentation**([https://datatracker.ietf.org/doc/html/rfc6020#section-7.15]()) 
`If the target node is a container, list, case, input, output, or notification node, the "container", "leaf", "list", "leaf-list", "uses", and "choice" statements can be used within the "augment" statement.` It does not include rpc node at all.
 
2. In **Yang version: 1.1**, **action** can mirror actions from outside models to target without touching target yang-models. Instruction on **Yang version 1.1** action and augmentation([https://datatracker.ietf.org/doc/html/rfc7950#section-7.15](), [https://datatracker.ietf.org/doc/html/rfc7950#section-7.17]())
`The "action" statement is used to define an operation connected to a specific container or list data node.`
`If the target node is a container or list node, the "action" and "notification" statements can be used within the "augment" statement.`

3. SONiC yang guideline: https://github.com/sonic-net/SONiC/blob/master/doc/mgmt/SONiC_YANG_Model_Guidelines.md. 
` This document lists the guidelines, which will be used to write YANG Modules for SONiC. These YANG Modules (called SONiC YANG models) will be primarily based on or represent the ABNF.json of SONiC, and the syntax of YANG models must follow RFC 7950 (https://tools.ietf.org/html/rfc7950). `

4. Restconf rules(<https://datatracker.ietf.org/doc/html/rfc8040>): 
`An action is invoked as: POST {+restconf}/data/<data-resource-identifier>/<action> where <data-resource-identifier> contains the path to the data node where the action is defined, and <action> is the name of the action.
For example, if "module-A" defined a "reset-all" action in the container "interfaces", then invoking this action would be requested as follows:
POST /restconf/data/module-A:interfaces/reset-all HTTP/1.1
      Server: example.com`

#### How I did it
### CLI (direct Redis)

```
config ... action get-ocm-raw      APPL_DB                  orchagent (C++)              syncd
     │                                │                          │                          │
     │ NotificationProducer.send()    │─────────────────────────>│ NotificationConsumer     │
     │   op="get-ocm-raw"             │  OTN_OCM_NOTIFICATION    │   handleRpcRequest()     │
     │   data="OCM0-0"                │                          │     → doGetOcmRaw()      │
     │                                │                          │       → SAI get ────────>│
     │                                │                          │       ← s8list  <───────│
     │ NotificationConsumer.pop()     │<─────────────────────────│ send("SUCCESS",...)      │
     │ display table                  │  OTN_OCM_REPLY           │                          │
```

### REST (via translib)

```
REST POST /restconf/data
  └─→ translib.Action() → rpc_get_ocm_raw_cb
        ├── subscribe OTN_OCM_REPLY
        ├── publish to OTN_OCM_NOTIFICATION
        ├── wait for reply (10s timeout)
        └── build JSON response
```

#### Which release branch to backport (provide reason below if selected)
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [x] 202411
- [ ] 202505
- [ ] 202511

#### SONiC bugs and improvements

1. `If the RPC operation is invoked without errors and if the "rpc" or "action" statement has no "output" section, the response message MUST NOT include a message-body and MUST send a "204 No Content" status-line instead.` Right now it return 200.
2. sonic-mgmt-common unit test must run under /usr/sbin.
3. gNMI/gNOI has not implemented yet.
4. Don't understand why he commented out these lines.
https://github.com/sonic-net/sonic-sairedis/commit/6b11376fb6f964816432c88e356d414e5f30b8ec#diff-d6e7a20338019b58d64388db0f77a70af4fe6b6e9295e38a53bd90abd106256f