### PR TITLE
Fix sonic-yanggen compile failure

### DIFF
--- a/platform/otn-kvm/sonic-yanggen/debian/rules
+++ b/platform/otn-kvm/sonic-yanggen/debian/rules
@@ -30,9 +30,9 @@ override_dh_auto_build:
 	@echo "========================================"
 	@echo "Building libyang from source"
 	@echo "========================================"
-	# Clone and build libyang from source
+	# Clone and build libyang from source (pinned to tag v4.2.2)
 	@if [ ! -d "$(CURDIR)/libyang" ]; then \
-		git clone https://github.com/CESNET/libyang.git $(CURDIR)/libyang && \
+		git clone --depth 1 --branch v4.2.2 https://github.com/CESNET/libyang.git $(CURDIR)/libyang && \
 		cd $(CURDIR)/libyang && \
 		mkdir -p build && cd build && \
 		cmake -DCMAKE_INSTALL_PREFIX=$(CURDIR)/libyang-install -DCMAKE_INSTALL_INCLUDEDIR=include ..&& \
@@ -50,7 +50,7 @@ override_dh_auto_build:
 	@export CFLAGS="-I$(CURDIR)/libyang-install/include" && \
 	export LDFLAGS="-L$(CURDIR)/libyang-install/lib" && \
 	export LD_LIBRARY_PATH=$(CURDIR)/libyang-install/lib:$$LD_LIBRARY_PATH && \
-	pip3 install --target=$(CURDIR)/python-deps libyang
+	pip3 install --target=$(CURDIR)/python-deps libyang==4.0.0
 	
 	@echo "========================================"
 	@echo "Auto-discovering devices with YANG configs..."


### PR DESCRIPTION
Pin libyang: v4.2.2 and pyang: 4.0.0

#### Related issue
- https://github.com/sonic-otn/sonic-buildimage/issues/27

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

#### How to verify it

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

